### PR TITLE
Fix package name to django-speedboost

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Django-Speedboost is currently compiled for Django 1.8.8 only. Install with:
 
 .. code-block:: bash
 
-    pip install django_speedboost
+    pip install django-speedboost
 
 If you get missing header compilation errors, install your distribution's python library development headers, for
 example on Ubuntu:

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ site_packages_path = sysconfig.get_python_lib(plat_specific=True)
 site_packages_rel_path = site_packages_path[len(sysconfig.EXEC_PREFIX) + 1:]
 
 setup(
-    name="django_speedboost",
+    name="django-speedboost",
     author="Alex Damian",
     author_email="alex@yplanapp.com",
     version=version,


### PR DESCRIPTION
Running `python setup.py register` with this _might_ fix it on PyPI
